### PR TITLE
ecr permissionを追加

### DIFF
--- a/terraform/ecr.tf
+++ b/terraform/ecr.tf
@@ -7,7 +7,23 @@ resource "aws_ecr_repository" "lambda" {
   }
 }
 
-# resource "aws_ecr_repository_policy" "lambda" {
-#   repository = aws_ecr_repository.lambda.name
-#   policy =
-# }
+resource "aws_ecr_repository_policy" "lambda" {
+  repository = aws_ecr_repository.lambda.name
+  policy = data.aws_iam_policy_document.lambda_ecr_policy.json
+}
+
+data "aws_iam_policy_document" "lambda_ecr_policy" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+
+    actions = [
+      "ecr:BatchGetImage",
+      "ecr:GetDownloadUrlForLayer",
+    ]
+  }
+}

--- a/terraform/lambda_function.tf
+++ b/terraform/lambda_function.tf
@@ -10,8 +10,6 @@ resource "aws_lambda_function" "test_lambda" {
   }
 }
 
-
-
 data "aws_ecr_image" "service_image" {
   repository_name = "lambda"
   image_tag       = "initial"


### PR DESCRIPTION
https://docs.aws.amazon.com/ja_jp/lambda/latest/dg/images-create.html#gettingstarted-images-permissions

>Amazon ECR リポジトリにこれらの権限が含まれていない場合、Lambda は ecr:BatchGetImage および ecr:GetDownloadUrlForLayer をコンテナイメージリポジトリのアクセス許可に追加します。

lambdaが勝手に追加するっぽい